### PR TITLE
Move to publish_message instead of publish_topic

### DIFF
--- a/lib/topological_inventory/ingress_api/admins.rb
+++ b/lib/topological_inventory/ingress_api/admins.rb
@@ -18,10 +18,9 @@ module TopologicalInventory
       ]}) do
     cross_origin
 
-    messaging_client.publish_topic(
+    messaging_client.publish_message(
       :service => "topological_inventory-persister",
-      :event   => "inventory",
-      :sender  => "topological_inventory-ingress_api",
+      :message => "save_inventory",
       :payload => JSON.load(request.body.read),
     )
 


### PR DESCRIPTION
ManageIQ::Messaging implemented publish_message for the kafka backend so
we don't need to use publish_topic anymore.

Merge together with: https://github.com/ManageIQ/topological_inventory-core/pull/33