### PR TITLE
Add a lives_on property to ContainerNode

### DIFF
--- a/public/doc/swagger-2-v0.0.2.yaml
+++ b/public/doc/swagger-2-v0.0.2.yaml
@@ -147,6 +147,8 @@ definitions:
           type: "integer"
         memory:
           type: "integer"
+        lives_on:
+          $ref: "#/definitions/InventoryObjectLazy"
         source_created_at:
           type: "string"
           format: "date-time"


### PR DESCRIPTION
https://github.com/ManageIQ/topological_inventory-core/pull/57 Added a `ContainerNode#lives_on` polymorpic association, this allows collectors to set the cross-link