### PR TITLE
Update to rails 5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'json-schema', '~> 2.8'
 gem 'pg',          '~> 1.0', :require => false
 gem 'puma',        '~> 3.0'
 gem 'rack-cors',   '>= 0.4.1'
-gem 'rails',       '~> 5.1.6.1'
+gem 'rails',       '~> 5.2.1.1'
 
 gem 'manageiq-messaging'
 gem 'topological_inventory-core', :git => 'https://github.com/ManageIQ/topological_inventory-core', :branch => 'master'

--- a/config/initializers/callback_terminator.rb
+++ b/config/initializers/callback_terminator.rb
@@ -1,6 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Do not halt callback chains when a callback returns false. This is a new
-# Rails 5.0 default, so it is introduced as a configuration option to ensure
-# that apps made with earlier versions of Rails are not affected when upgrading.
-ActiveSupport.halt_callback_chains_on_return_false = false


### PR DESCRIPTION
topological_inventory-core was updated to rails 5.2 in https://github.com/ManageIQ/topological_inventory-core/pull/81 so this must be updated as well.