### PR TITLE
Document usage of the openapi_generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /spec/reports/
 /tmp/
 /v2_key
+/public/doc/*.jar

--- a/README.md
+++ b/README.md
@@ -29,6 +29,61 @@ To list all your routes, use:
 bin/rake routes
 ```
 
+## Generate client to any language on any OS using openapi_generator
+
+Follow https://github.com/OpenAPITools/openapi-generator instructions
+using the yaml file e.g. `public/doc/swagger-2-v0.0.2.yaml`
+
+## Quick setup for ruby client generated on Fedora/RHEL:
+Install java 8:
+
+``` 
+ yum search java | grep openjdk
+ yum install java-1.8.0-openjdk-headless.x86_64
+ yum install java-1.8.0-openjdk-devel.x86_64
+```
+
+Install maven:
+
+``` 
+ # Download maven bin tar from http://maven.apache.org/download.cgi
+ sudo tar xzf apache-maven-3.6.0-bin.tar.gz /opt/apache-maven-3.6.0
+ sudo ln -s /opt/apache-maven-3.6.0 /opt/maven
+ 
+ sudo vi /etc/profile.d/maven.sh
+ # and add:
+ export M2_HOME=/opt/maven
+ export PATH=${M2_HOME}/bin:${PATH}
+ 
+ # then
+ source /etc/profile.d/maven.sh
+```
+
+Get the openapi-generator:
+
+```
+ git clone https://github.com/openapitools/openapi-generator
+ cd openapi-generator
+ mvn clean package
+ cd ..
+```
+
+Fetch the ruby client git repo:
+ 
+```
+git clone git@github.com:ManageIQ/topological_inventory-ingress_api-client-ruby.git
+```
+
+Build the client:
+
+```
+ cd topological_inventory-ingress-api
+ ./generate_ruby_client.sh
+ 
+ cd ../topological_inventory-ingress_api-client-ruby
+ # and commit&push the client changes
+```
+
 ## License
 
 This project is available as open source under the terms of the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/README.md
+++ b/README.md
@@ -34,38 +34,14 @@ bin/rake routes
 Follow https://github.com/OpenAPITools/openapi-generator instructions
 using the yaml file e.g. `public/doc/swagger-2-v0.0.2.yaml`
 
+## Prerequisities
+- Java Runtime Environment (JRE) 8
+
 ## Quick setup for ruby client generated on Fedora/RHEL:
-Install java 8:
-
-``` 
- yum search java | grep openjdk
- yum install java-1.8.0-openjdk-headless.x86_64
- yum install java-1.8.0-openjdk-devel.x86_64
 ```
-
-Install maven:
-
-``` 
- # Download maven bin tar from http://maven.apache.org/download.cgi
- sudo tar xzf apache-maven-3.6.0-bin.tar.gz /opt/apache-maven-3.6.0
- sudo ln -s /opt/apache-maven-3.6.0 /opt/maven
- 
- sudo vi /etc/profile.d/maven.sh
- # and add:
- export M2_HOME=/opt/maven
- export PATH=${M2_HOME}/bin:${PATH}
- 
- # then
- source /etc/profile.d/maven.sh
-```
-
-Get the openapi-generator:
-
-```
- git clone https://github.com/openapitools/openapi-generator
- cd openapi-generator
- mvn clean package
- cd ..
+# Download JAR of latest stable openapi-generator
+cd topological_inventory-ingress-api
+wget http://central.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.4/openapi-generator-cli-3.3.4.jar -O public/doc/openapi-generator-cli.jar
 ```
 
 Fetch the ruby client git repo:

--- a/generate_ruby_client.sh
+++ b/generate_ruby_client.sh
@@ -1,4 +1,4 @@
-java -jar ../openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
+java -jar public/doc/openapi-generator-cli.jar generate \
    -i public/doc/swagger-2-v0.0.2.yaml \
    -c openapi_config.json \
    -g ruby \

--- a/generate_ruby_client.sh
+++ b/generate_ruby_client.sh
@@ -1,0 +1,5 @@
+java -jar ../openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar generate \
+   -i public/doc/swagger-2-v0.0.2.yaml \
+   -c openapi_config.json \
+   -g ruby \
+   -o ../topological_inventory-ingress_api-client-ruby

--- a/openapi_config.json
+++ b/openapi_config.json
@@ -1,0 +1,4 @@
+{
+  "moduleName": "TopologicalInventoryIngressApiClient",
+  "gemName": "topological_inventory-ingress_api-client"
+}


### PR DESCRIPTION
Document usage of the openapi_generator and prepare a script that will generate the existing ruby client based on the yaml.
Replaces #26 using stable openapi-generator v 3.3.4