### PR TITLE
Yaml service_offering and service_plan

### DIFF
--- a/public/doc/swagger-2-v0.0.2.yaml
+++ b/public/doc/swagger-2-v0.0.2.yaml
@@ -546,6 +546,9 @@ definitions:
           type: string
         support_url:
           type: string
+        extra:
+          type: object
+          properties: {}
         source_created_at:
           type: string
           format: date-time
@@ -605,6 +608,9 @@ definitions:
           type: string
           format: date-time
         source_deleted_at:
+          type: string
+          format: date-time
+        resource_timestamp:
           type: string
           format: date-time
         create_json_schema:


### PR DESCRIPTION
`ServiceOffering:extra` can store type of job_template/workflow_job_template (needed for AnsibleTower collector)
`ServicePlan:resource_timestamp` was missing in yaml

related: https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/26