### PR TITLE
Cache the messaging client connection

### DIFF
--- a/app/controllers/topological_inventory/ingress_api/v0/inventory_controller.rb
+++ b/app/controllers/topological_inventory/ingress_api/v0/inventory_controller.rb
@@ -1,44 +1,34 @@
+require "topological_inventory/ingress_api/messaging_client"
+
 module TopologicalInventory
   module IngressApi
     module V0
       class InventoryController < ApplicationController
         skip_before_action :verify_authenticity_token
         def save_inventory
-          messaging_client.publish_message(
-            :service => "platform.topological-inventory.persister",
-            :message => "save_inventory",
-            :payload => JSON.parse(request.body.read),
-          )
+          payload = JSON.parse(request.body.read)
+
+          TopologicalInventory::IngressApi.with_messaging_client do |client|
+            client.publish_message(save_inventory_payload(payload))
+          end
 
           render status: 200, :json => {
             :message => "ok",
-          }.to_json
-        rescue Kafka::MessageSizeTooLarge => e
-          render :status => 500, :json => {
-            :message    => e.message,
-            :error_code => e.class.to_s,
           }.to_json
         rescue => e
           render :status => 500, :json => {
             :message    => e.message,
             :error_code => e.class.to_s,
           }.to_json
-
-          raise e
         end
 
         private
 
-        def messaging_client
-          ManageIQ::Messaging::Client.open(messaging_opts)
-        end
-
-        def messaging_opts
+        def save_inventory_payload(raw_payload)
           {
-            :protocol => :Kafka,
-            :host     => ENV["QUEUE_HOST"] || "localhost",
-            :port     => ENV["QUEUE_PORT"] || "9092",
-            :encoding => "json",
+            :service => "platform.topological-inventory.persister",
+            :message => "save_inventory",
+            :payload => raw_payload,
           }
         end
       end

--- a/lib/topological_inventory/ingress_api/messaging_client.rb
+++ b/lib/topological_inventory/ingress_api/messaging_client.rb
@@ -1,0 +1,34 @@
+module TopologicalInventory
+  module IngressApi
+    def self.with_messaging_client
+      messaging_client ||= raw_messaging_client
+      raise if messaging_client.nil?
+
+      begin
+        yield messaging_client
+      rescue Kafka::ConnectionError
+        messaging_client.close
+        self.messaging_client = nil
+
+        raise
+      end
+    end
+
+    private_class_method def self.messaging_client
+      Thread.current[:messaging_client]
+    end
+
+    private_class_method def self.messaging_client=(value)
+      Thread.current[:messaging_client] = value
+    end
+
+    private_class_method def self.raw_messaging_client
+      ManageIQ::Messaging::Client.open(
+        :encoding => "json",
+        :host     => ENV["QUEUE_HOST"] || "localhost",
+        :port     => ENV["QUEUE_PORT"] || "9092",
+        :protocol => :Kafka,
+      )
+    end
+  end
+end

--- a/lib/topological_inventory/ingress_api/messaging_client.rb
+++ b/lib/topological_inventory/ingress_api/messaging_client.rb
@@ -6,7 +6,11 @@ module TopologicalInventory
 
       begin
         yield messaging_client
-      rescue Kafka::ConnectionError
+      rescue Kafka::MessageSizeTooLarge
+        # Don't reset the connection for user-error
+        raise
+      rescue Kafka::Error
+        # If we hit an underlying kafka error then reset the connection
         messaging_client.close
         self.messaging_client = nil
 

--- a/lib/topological_inventory/ingress_api/messaging_client.rb
+++ b/lib/topological_inventory/ingress_api/messaging_client.rb
@@ -1,7 +1,7 @@
 module TopologicalInventory
   module IngressApi
     def self.with_messaging_client
-      messaging_client ||= raw_messaging_client
+      messaging_client ||= new_messaging_client
       raise if messaging_client.nil?
 
       begin
@@ -26,7 +26,7 @@ module TopologicalInventory
       Thread.current[:messaging_client] = value
     end
 
-    private_class_method def self.raw_messaging_client
+    private_class_method def self.new_messaging_client
       ManageIQ::Messaging::Client.open(
         :encoding => "json",
         :host     => ENV["QUEUE_HOST"] || "localhost",


### PR DESCRIPTION
Instead of opening a new connection every request, cache the kafka
client connection and re-initialize if we hit a connection error.