### PR TITLE
Add namespace to tag

### DIFF
--- a/public/doc/swagger-2-v0.0.2.yaml
+++ b/public/doc/swagger-2-v0.0.2.yaml
@@ -702,10 +702,13 @@ definitions:
     - type: object
       required:
       - name
+      - namespace
       properties:
         name:
           type: string
         value:
+          type: string
+        namespace:
           type: string
   Vm:
     allOf:


### PR DESCRIPTION
When we extract sources we won't be able to get the source_type from the source so the collector will have to fill in the tag namespace.