### PR TITLE
OpenAPI validation using manageiq-api-common

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,40 @@
 class ApplicationController < ActionController::API
+  before_action :validate_request
+
   def body_params
     ActionController::Parameters.new(JSON.parse(request.body.read))
+  end
+
+  # Validates against openapi.json
+  # - only for HTTP POST/PATCH
+  def validate_request
+    return unless request.post? || request.patch?
+
+    self.class.send(:api_doc).validate!(request.method,
+                                        request.path,
+                                        self.class.send(:api_version),
+                                        body_params.as_json)
+  rescue OpenAPIParser::OpenAPIError => exception
+    render :json   => {:message    => exception.message,
+                       :error_code => exception.class.to_s},
+           :status => :bad_request
+  end
+
+  private_class_method def self.api_version
+    @api_version ||= name.split("::")[2].downcase[1..-1].gsub(/x/, ".")
+  end
+
+  private_class_method def self.api_doc
+    return @api_doc if @api_doc.present?
+
+    # ManageIQ::Api::Common::Docs caches only major:minor version
+    version_parts = api_version.split('.')
+    doc_api_version = if version_parts.size > 2
+                        version_parts[0..1].join('.')
+                      else
+                        api_version
+                      end
+
+    @api_doc = TopologicalInventory::IngressApi::Docs[doc_api_version]
   end
 end

--- a/app/controllers/topological_inventory/ingress_api/v0/inventory_controller.rb
+++ b/app/controllers/topological_inventory/ingress_api/v0/inventory_controller.rb
@@ -5,25 +5,18 @@ require "topological_inventory/ingress_api/messaging_client"
 module TopologicalInventory
   module IngressApi
     module V0
-      class InventoryController < ApplicationController
-        skip_before_action :verify_authenticity_token
+      class InventoryController < ::ApplicationController
+        include TopologicalInventory::IngressApi::MessagingClient
 
         def save_inventory
           json_payload = request.body.read
           payload      = JSON.parse(json_payload)
           dup_payload  = payload.deep_dup
 
-          root = OpenAPIParser.parse(TopologicalInventory::IngressApi::Docs["0.0"].content,
-                                     :coerce_value => true, :datetime_coerce_class => DateTime)
-
-          request_operation = root.request_operation(:post, '/inventory')
-
-          request_operation.validate_request_body('application/json', payload)
-
           retry_count = 0
           retry_max   = 1
 
-          TopologicalInventory::IngressApi.with_messaging_client do |client|
+          self.class.with_messaging_client do |client|
             begin
               # TODO(lsmola) can use this after https://github.com/ManageIQ/manageiq-messaging/pull/45 is released
               # client.publish_message(save_inventory_payload(json_payload))
@@ -36,11 +29,6 @@ module TopologicalInventory
 
           render status: 200, :json => {
             :message => "ok",
-          }.to_json
-        rescue OpenAPIParser::OpenAPIError => e
-          render :status => :bad_request, :json => {
-            :message    => e.message,
-            :error_code => e.class.to_s,
           }.to_json
         rescue => e
           render :status => 500, :json => {

--- a/lib/topological_inventory/ingress_api/messaging_client.rb
+++ b/lib/topological_inventory/ingress_api/messaging_client.rb
@@ -1,44 +1,56 @@
 module TopologicalInventory
   module IngressApi
-    def self.with_messaging_client
-      messaging_client ||= new_messaging_client
-      raise if messaging_client.nil?
+    module MessagingClient
+      extend ActiveSupport::Concern
 
-      begin
-        yield messaging_client
-      rescue Kafka::MessageSizeTooLarge
-        # Don't reset the connection for user-error
-        raise
-      rescue Kafka::Error
-        # If we hit an underlying kafka error then reset the connection
-        messaging_client.close
-        self.messaging_client = nil
-
-        raise
+      included do
+        private_class_method :messaging_client,
+                             :messaging_client=,
+                             :new_messaging_client
       end
-    end
 
-    private_class_method def self.messaging_client
-      Thread.current[:messaging_client]
-    end
+      module ClassMethods
+        def with_messaging_client
+          messaging_client ||= new_messaging_client
+          raise if messaging_client.nil?
 
-    private_class_method def self.messaging_client=(value)
-      Thread.current[:messaging_client] = value
-    end
+          begin
+            yield messaging_client
+          rescue Kafka::MessageSizeTooLarge
+            # Don't reset the connection for user-error
+            raise
+          rescue Kafka::Error
+            # If we hit an underlying kafka error then reset the connection
+            messaging_client.close
+            self.messaging_client = nil
 
-    private_class_method def self.new_messaging_client(retry_max = 1)
-      retry_count = 0
-      begin
-        ManageIQ::Messaging::Client.open(
-          :encoding => "json",
-          :host     => ENV["QUEUE_HOST"] || "localhost",
-          :port     => ENV["QUEUE_PORT"] || "9092",
-          :protocol => :Kafka,
-        )
+            raise
+          end
+        end
+
+        def messaging_client
+          Thread.current[:messaging_client]
+        end
+
+        def messaging_client=(value)
+          Thread.current[:messaging_client] = value
+        end
+
+        def new_messaging_client(retry_max = 1)
+          retry_count = 0
+          begin
+            ManageIQ::Messaging::Client.open(
+              :encoding => "json",
+              :host     => ENV["QUEUE_HOST"] || "localhost",
+              :port     => ENV["QUEUE_PORT"] || "9092",
+              :protocol => :Kafka,
+            )
+          end
+        rescue Kafka::ConnectionError
+          retry_count += 1
+          retry unless retry_count > retry_max
+        end
       end
-    rescue Kafka::ConnectionError
-      retry_count += 1
-      retry unless retry_count > retry_max
     end
   end
 end

--- a/spec/requests/api/v0.1/inventory_spec.rb
+++ b/spec/requests/api/v0.1/inventory_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe("v0.0.2 - Inventory") do
         client = double
         allow(client).to receive(:publish_message)
 
-        allow(TopologicalInventory::IngressApi).to receive(:with_messaging_client).and_yield(client)
+        allow(TopologicalInventory::IngressApi::V0x0x2::InventoryController).to receive(:with_messaging_client).and_yield(client)
       end
 
       let(:headers) do


### PR DESCRIPTION
This PR moves OpenAPI validator to `ManageIQ::Api::Common::Docs::DocV3`.

Also fixes `InventoryController` superclass

---

- [x] **depends on** https://github.com/ManageIQ/manageiq-api-common/pull/80

