### PR TITLE
OpenAPI generator 3.3.4->4.2.0

### DIFF
--- a/lib/tasks/client_generate.rake
+++ b/lib/tasks/client_generate.rake
@@ -6,7 +6,7 @@ class ClientGenerator
   require 'json'
   require 'uri'
 
-  VERSION = "3.3.4".freeze
+  VERSION = "4.2.0".freeze
   SOURCE_URL = "http://central.maven.org/maven2/org/openapitools/openapi-generator-cli".freeze
 
   def msg(message)
@@ -54,6 +54,13 @@ class ClientGenerator
     File.write(yaml_spec, JSON.parse(File.read(json_spec)).to_yaml(:line_width => -1).sub("---\n", "").tap { |c| c.gsub!("- NULL VALUE", "- null") })
   end
 
+  # Remove source files which are not present but won't be deleted by the generator-cli jar
+  def clean_target_directories(client_dir)
+    FileUtils.rm_r(client_dir.join("docs")) if client_dir.join("docs").exist?
+    FileUtils.rm_r(client_dir.join("spec")) if client_dir.join("spec").exist?
+    FileUtils.rm_r(client_dir.join("lib"))  if client_dir.join("lib").exist?
+  end
+
   def generate_client(client_dir, lng)
     msg("Ingress API Version: #{api_version}")
     msg("Using OpenAPI Generator CLI Jar:   #{generator_cli_jar}")
@@ -63,6 +70,7 @@ class ClientGenerator
 
     msg("\nGenerating API #{lng} Client ...")
     generate_yaml_file(openapi_file, openapi_yaml_file)
+    # clean_target_directories(client_dir)
     system("java -jar #{generator_cli_jar} generate -i #{openapi_yaml_file} -c #{generator_config} -g #{lng} -o #{client_dir}")
   end
 end

--- a/public/doc/openapi-3-v0.0.2.json
+++ b/public/doc/openapi-3-v0.0.2.json
@@ -1624,7 +1624,10 @@
                 "type": "object"
               },
               {
-                "type": "array"
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             ]
           },

--- a/spec/requests/api/v0.1/inventory_spec.rb
+++ b/spec/requests/api/v0.1/inventory_spec.rb
@@ -1,5 +1,6 @@
 require "rails_helper"
 require 'topological_inventory/ingress_api/messaging_client'
+require "pry-byebug"
 
 RSpec.describe("v0.0.2 - Inventory") do
   describe("/topological_inventory/ingress_api/0.0.2/inventory") do

--- a/spec/requests/api/v0.1/inventory_spec.rb
+++ b/spec/requests/api/v0.1/inventory_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe("v0.0.2 - Inventory") do
 
           expect(@response.code).to eq(failed_validation_code)
           match_response_message(
-            /.*?(class is Integer but it's not valid string).*?(\/schemas\/ContainerGroup\/).*?(properties\/source_ref).*?/
+            /.*?(\/schemas\/ContainerGroup\/).*?(properties\/source_ref).*?(expected string, but received Integer).*?/
           )
         end
 
@@ -276,7 +276,7 @@ RSpec.describe("v0.0.2 - Inventory") do
 
           expect(@response.code).to eq(failed_validation_code)
           match_response_message(
-            /.*?(class is Float but it's not valid string).*?(\/schemas\/ContainerGroup\/).*?(properties\/source_ref).*?/
+            /.*?(\/schemas\/ContainerGroup\/).*?(properties\/source_ref).*?(expected string, but received Float).*?/
           )
         end
 
@@ -287,7 +287,7 @@ RSpec.describe("v0.0.2 - Inventory") do
 
           expect(@response.code).to eq(failed_validation_code)
           match_response_message(
-            /.*?(class is Integer but it's not valid string).*?(\/schemas\/ContainerGroup\/).*?(properties\/resource_timestamp).*?/
+            /.*?(\/schemas\/ContainerGroup\/).*?(properties\/resource_timestamp).*?(expected string, but received Integer).*?/
           )
         end
 
@@ -298,7 +298,7 @@ RSpec.describe("v0.0.2 - Inventory") do
 
           expect(@response.code).to eq(failed_validation_code)
           match_response_message(
-            /.*?(class is String but it's not valid string).*?(\/schemas\/ContainerGroup\/).*?(properties\/resource_timestamp).*?/
+            /.*?(\/schemas\/ContainerGroup\/).*?(properties\/resource_timestamp).*?(expected string, but received String).*?/
           )
         end
 
@@ -329,7 +329,7 @@ RSpec.describe("v0.0.2 - Inventory") do
 
           expect(@response.code).to eq(failed_validation_code)
           match_response_message(
-            /.*?(class is NilClass but it's not valid number).*?(\/schemas\/ContainerNode\/).*?(properties\/allocatable_cpus).*?/
+            /.*?(\/schemas\/ContainerNode\/).*?(properties\/allocatable_cpus).*?(expected number, but received NilClass).*?/
           )
         end
 
@@ -340,7 +340,7 @@ RSpec.describe("v0.0.2 - Inventory") do
 
           expect(@response.code).to eq(failed_validation_code)
           match_response_message(
-            /.*?(class is Array but it's not valid object).*?(\/schemas\/ContainerNode\/).*?(properties\/node_info).*?/
+            /.*?(\/schemas\/ContainerNode\/).*?(properties\/node_info).*?(expected object, but received Array).*?/
           )
         end
 
@@ -351,7 +351,7 @@ RSpec.describe("v0.0.2 - Inventory") do
 
           expect(@response.code).to eq(failed_validation_code)
           match_response_message(
-            /.*?(class is Hash but it's not valid array).*?(\/schemas\/ContainerNode\/).*?(properties\/conditions).*?/
+            /.*?(\/schemas\/ContainerNode\/).*?(properties\/conditions).*?(expected array, but received Hash).*?/
           )
         end
       end
@@ -364,7 +364,7 @@ RSpec.describe("v0.0.2 - Inventory") do
 
           expect(@response.code).to eq(failed_validation_code)
           match_response_message(
-            /.*?(required parameters source_ref not exist).*?(\/schemas\/ContainerGroup\/).*?/
+            /.*?(\/schemas\/ContainerGroup\/).*?(missing required parameters: source_ref).*?/
           )
         end
 
@@ -375,7 +375,7 @@ RSpec.describe("v0.0.2 - Inventory") do
 
           expect(@response.code).to eq(failed_validation_code)
           match_response_message(
-            /.*?(\/schemas\/ContainerGroup\/).*?(properties\/source_ref).*?(don't allow null)/
+            /.*?(\/schemas\/ContainerGroup\/).*?(properties\/source_ref).*?(does not allow null values)/
           )
         end
       end
@@ -413,7 +413,7 @@ RSpec.describe("v0.0.2 - Inventory") do
 
           expect(@response.code).to eq(failed_validation_code)
           match_response_message(
-            /.*?(made_up_ref isn't match \^cross_link_vms\$).*?(\/schemas\/CrossLinkVmReference\/).*?(properties\/inventory_collection_name).*?/
+            /.*?(\/schemas\/CrossLinkVmReference\/).*?(properties\/inventory_collection_name).*?(\^cross_link_vms\$ does not match value: made_up_ref).*?/
           )
         end
 
@@ -451,7 +451,7 @@ RSpec.describe("v0.0.2 - Inventory") do
 
           expect(@response.code).to eq(failed_validation_code)
           match_response_message(
-            /.*?(properties made_up_attr are not defined).*?(\/schemas\/ContainerGroup).*?/
+            /.*?(\/schemas\/ContainerGroup).*?(does not define properties: made_up_attr).*?/
           )
         end
 

--- a/spec/requests/api/v0.1/inventory_spec.rb
+++ b/spec/requests/api/v0.1/inventory_spec.rb
@@ -1,6 +1,5 @@
 require "rails_helper"
 require 'topological_inventory/ingress_api/messaging_client'
-require "pry-byebug"
 
 RSpec.describe("v0.0.2 - Inventory") do
   describe("/topological_inventory/ingress_api/0.0.2/inventory") do


### PR DESCRIPTION
`clean_target_directories` cannot be enabled by default because of `inventory.rb` is in gitignore (bad generating)

---

* json generated by https://github.com/ManageIQ/topological_inventory-persister/pull/46
* client: https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/57