### PR TITLE
Switch to released version of api-common

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,16 +3,16 @@ source 'https://rubygems.org'
 plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem 'json-schema',       '~> 2.8'
-gem 'manageiq-loggers',  '~> 0.1'
-gem 'prometheus-client', '~> 0.8.0'
-gem 'puma',              '~> 3.0'
-gem 'rack-cors',         '>= 0.4.1'
-gem 'rails',             '~> 5.2.2'
+gem 'json-schema',         '~> 2.8'
+gem 'manageiq-api-common', '~> 2.0', '>= 2.0.1'
+gem 'manageiq-loggers',    '~> 0.1'
+gem 'prometheus-client',   '~> 0.8.0'
+gem 'puma',                '~> 3.0'
+gem 'rack-cors',           '>= 0.4.1'
+gem 'rails',               '~> 5.2.2'
 
 gem 'manageiq-messaging'
 
-gem 'manageiq-api-common', :git => 'https://github.com/ManageIQ/manageiq-api-common', :branch => 'master'
 gem 'topological_inventory-core', :git => 'https://github.com/ManageIQ/topological_inventory-core', :branch => 'master'
 
 group :development, :test do


### PR DESCRIPTION
Don't point to master for manageiq-api-common